### PR TITLE
Luku 5 korjauksia 

### DIFF
--- a/data/luku-5/1-ttk-91.md
+++ b/data/luku-5/1-ttk-91.md
@@ -6,7 +6,7 @@ hidden: false
 
 <div>
 <lead>
-Tässä osiossa käymme läpi esimerkkitietokoneena käytettävän opetuskäyttöön suunnitellun tietokoneen ttk-91 perusrakenne ja sen ohjelmoinnin symbolisella konekielellä. (Aliohjelmien toteutus käsitellään seuraavassa luvussa.)
+Tässä osiossa käymme läpi esimerkkitietokoneena käytettävän opetuskäyttöön suunnitellun tietokoneen ttk-91 perusrakenne ja sen ohjelmointi symbolisella konekielellä. (Aliohjelmien toteutus käsitellään seuraavassa luvussa.)
 </lead>
 </div>
 
@@ -15,25 +15,25 @@ Tässä osiossa käymme läpi esimerkkitietokoneena käytettävän opetuskäytt�
 Yleiskuva ttk-91 arkkitehtuurissa annettiin kurssin Tietokoneen toiminnan perusteet luvussa 2. Jos nämä tiedot eivät ole ihan tuoreessa muistissa, voit haluta lukea luvun 2 uudelleen nyt. Näitä tietoja kerrataan (vähän) ja täsmennetään nyt tässä.
 
 ## Rekisterit
-Ttk-91 suorittimella on 8 konekäskyissä viitattavaa rekisteriä. Ne on nimetty R0-R7, mutta rekisterillä R6 on myös nimi SP (stack pointer) ja rekisterilla R7 nimi FP (frame pointer). Näitä kahta rekisteriä käytetään aliohjelmien toteutuksessa, mikä on seuraavan luvun (Luku 6) aihepiiri. Rekisterit R0-R5 ovat ns. työrekistereitä - niihin voidaan tallettaa kaikkien operaatioiden tulos ja ne voivat sisältää aritmeettis-loogisten operaatioiden ensimmäisen operandin.
+Ttk-91 suorittimella on 8 konekäskyissä viitattavaa rekisteriä. Ne on nimetty R0 - R7. Näistä rekisterillä R6 on myös nimi SP (stack pointer eli pino-osoitin) ja rekisterilla R7 nimi FP (frame pointer eli kehysosoitin). Pino-osoitinta ja kehysosoitinta käytetään aliohjelmien toteutuksessa, joka on seuraavan luvun (Luku 6) aihepiiri. Rekisterit R0 - R5 ovat niin sanottuja työrekistereitä - niihin voidaan tallettaa kaikkien operaatioiden tulos ja ne voivat sisältää aritmeettis-loogisten operaatioiden ensimmäisen operandin.
 
-Rekistereitä R1-R7 (yleensä vain R1-R5) voi käyttää myös indeksirekisterinä jälkimmäisen operandin arvon määrittämisessä. Jos jälkimmäisen operandin arvon määrittämisessä ei tarvitse (haluta) käyttää indeksirekisteriä, tämä tieto pitää koodata jollain tavoin konekäskyyn. Ttk-91 koneessa koodaus on tehty käyttämällä indeksirekisterin numeroa 0. Konekäskyssä oleva indeksirekisteri R0 tarkoittaa siis, että jälkimmäisen operandin arvo saadaan ilman indeksirekisteriä.
+Rekistereitä R1 - R7 (yleensä vain R1 - R5) voi käyttää myös indeksirekisterinä jälkimmäisen operandin arvon määrittämisessä. Aina indeksirekisterin käytölle ei ole tarvetta. Konekäskyn bittiesityksessä on kuitenkin paikka kahta rekisteriä varten, joten jos jälkimmäisen operandin arvon määrittämisessä ei tarvitse käyttää indeksirekisteriä, tämän tiedon on oltava jollain tavoin koodattu konekäskyyn. Ttk-91 -koneessa tämä koodaus on tehty siten, että kääntäjä asettaa konekäskyn bittiesityksessä indeksirekisteriksi rekisterin R0 merkitsemällä konekäskyn indeksirekisterin ilmaisevaan kohtaan arvon 0. Rekisterissä R0 saa olla käskyn suoritushetkellä mikä tahansa arvo, mutta se ei aiheuta mitään ongelmaa: ttk-91 -suoritin tulkitsee indeksirekisteristä haettavaksi arvoksi 0 sen sijaan että se hakisi R0:n todellisen arvon.
 
 <!-- kuva: ch-5-1-a-ttk91-suoritin    -->
 
-![Suoritin ja väylä tarkemmin. Väylä on jaettu kolmeen eri osaan, jotka ovat dataväylä, osoiteväylä ja kontrolliväylä. Suorittimen sisällä on neljä komponenttia, jotka ovat muistinhallintayksikkö MMU, rekisterit, aritmeettislooginen yksikkö ALU ja kontrolliyksikkö CU. Välimuisti puuttuu kuvasta kokonaan. Aritmeettisloogisessa yksikössä on esimerkin vuoksi mainittu ADD- ja MUL-suorituspiirit. Suorittimen komponentteja yhdistää niiden välinen omna sisäinen dataväylä ja niiden välisen kommunikoinnin toteuttavat kontrollisignaalit. Väylän lähellä on muistinhallintayksikkö MMU, jossa on sisäiset rajarekisterit Base ja Limit, muistin osoitusrekisteri MAR, muistin puskurirekisteri MBR ja väylän kontrollirekisteri BusCtl. Rekistereitä on kahdeksan kappaletta R0-R7. Kontrolliyksikkössä on neljä sisäistä rekisteriä. Ne ovat paikanlaskuri PC, käskyrekisteri IR, tilarekisteri SR ja tilapäisrekisteri TR.](./ch-5-1-a-ttk91-suoritin.svg)
+![Suoritin ja väylä tarkemmin. Väylä on jaettu kolmeen eri osaan, jotka ovat dataväylä, osoiteväylä ja kontrolliväylä. Suorittimen sisällä on neljä komponenttia, jotka ovat muistinhallintayksikkö MMU, rekisterit, aritmeettislooginen yksikkö ALU ja kontrolliyksikkö CU. Välimuisti puuttuu kuvasta kokonaan. Aritmeettisloogisessa yksikössä on esimerkin vuoksi mainittu ADD- ja MUL-suorituspiirit. Suorittimen komponentteja yhdistää niiden välinen oma sisäinen dataväylä ja niiden välisen kommunikoinnin toteuttavat kontrollisignaalit. Väylän lähellä on muistinhallintayksikkö MMU, jossa on sisäiset rajarekisterit Base ja Limit, muistin osoitusrekisteri MAR, muistin puskurirekisteri MBR ja väylän kontrollirekisteri BusCtl. Rekistereitä on kahdeksan kappaletta, R0 - R7. Kontrolliyksikkössä on neljä sisäistä rekisteriä. Ne ovat paikanlaskuri PC, käskyrekisteri IR, tilarekisteri SR ja tilapäisrekisteri TR.](./ch-5-1-a-ttk91-suoritin.svg)
 <div>
 <illustrations motive="ch-5-1-a-ttk91-suoritin"></illustrations>
 </div>
 
-Suorittimen kontrolliyksikössä on neljä nimettyä rekisteriä: PC, SR, IR ja TR. Paikanlaskuri PC (Program Counter) osoittaa aina seuravaksi suoritettavaan konekäskyyn. PC-rekisteriin voi konekäskyissä viitata epäsuorasti,jolloin esim. hyppykäsky asettaa PC:lle uuden arvon. Konekäskyillä voi ttk-91 koneessa PC:lle kuitenkin vain asettaa uusia arvoja, mutta sen nykyarvoa ei voi lukea mitenkään. (Joissakin todellisissa suorittimissa PC-rekisteri voi olla luettavissa ja kirjoitettavissa yleisrekistereiden tapaan.)
+Suorittimen kontrolliyksikössä on neljä nimettyä rekisteriä: PC, SR, IR ja TR. Paikanlaskuri PC (Program Counter) osoittaa aina seuravaksi suoritettavaan konekäskyyn. PC-rekisteriin voi konekäskyissä viitata epäsuorasti,jolloin esimerkiksi hyppykäsky asettaa PC:lle uuden arvon. Konekäskyillä voi ttk-91 koneessa PC:lle kuitenkin vain asettaa uusia arvoja, mutta sen nykyarvoa ei voi lukea mitenkään. (Joissakin todellisissa suorittimissa PC-rekisteri voi olla luettavissa ja kirjoitettavissa yleisrekistereiden tapaan.)
 
 Käskyrekisteri IR (Instruction Register) sisältää suoritettavana olevan konekäskyn, joka on juuri haettu muistista. Rekisteri IR on valmiiksi langoitettu sillä tavoin, että käskyn eri kentät (operaatiokoodi, nimettyjen rekistereiden numerot, jne) ovat sieltä helposti luettavissa.
 
 Rekisteri TR (Temporary Register) on tilapäisrekisteri, jota käytetään jälkimmäisen operandin arvon laskennassa. Todellisissa suorittimissa on hyvin paljon tilapäisrekistereitä, joita käytetään eri tarkoituksiin käskyjen suorituksen aikana.
 
-### Tilarekisteri TR
-Tilarekisterillä SR (State Register) on monta tehtävää. Bitit P ja I rajoittavat suorittimen toimintaa tämän konekäskyn suorituksen yhteydessä. Bitti P (Privileged mode) kertoo, tapahtuuko tämän konekäskyn suoritus nyt etuoikeutetussa tilassa vai ei. Etuoikeutetussa tilassa voidaan suorittaa kaikkia konekäskyjä ja viitata mihin päin tahansa muistia. Bitti P laitetaan päälle esimerkiksi keskeytyskäsittelijäänsiirtymisen yhteydessä ja se palautetaan enmnalleen sieltä palatessa.
+### Tilarekisteri SR
+Tilarekisterillä SR (State Register) on monta tehtävää. Bitit P ja D rajoittavat suorittimen toimintaa tämän konekäskyn suorituksen yhteydessä. Bitti P (Privileged mode) kertoo, tapahtuuko tämän konekäskyn suoritus nyt etuoikeutetussa tilassa vai ei. Etuoikeutetussa tilassa voidaan suorittaa kaikkia konekäskyjä ja viitata mihin päin tahansa muistia. Bitti P laitetaan päälle (arvoksi tulee 1) esimerkiksi keskeytyskäsittelijäänsiirtymisen yhteydessä ja se palautetaan ennalleen (arvoksi tulee 0) sieltä palatessa.
 
 <!-- kuva: ch-5-1-a2-ttk91-tilarekisteri    -->
 ![Yksi pitkä laatikko, jonka edessä teksti SR ja sisällä bitit GELOZUMISPD???. Vasemmanpuolimmaisen bitin alla on sen numero 31, bitin Z alla sen numero 27 ja bitin D alla sen numero 21.](./ch-5-1-a2-ttk91-tilarekisteri.svg)
@@ -41,7 +41,7 @@ Tilarekisterillä SR (State Register) on monta tehtävää. Bitit P ja I rajoitt
 <illustrations motive="ch-5-1-a2-ttk91-tilarekisteri"></illustrations>
 </div>
 
-Bitti I (Interrupts enable) kertoo, ovatko keskeytysten käsittelyt sallittuja tällä hetkellä (tämän konekäskyn suorituksen lopussa) vai ei. Jos jokin keskeytys tapahtuu ja bitti I on päällä (arvo 1), niin seuraavaksi suoritettava konekäsky ei olekaan PC:n osoittama käsky vaan kyseisen keskeytystyypin keskeytyskäsittelijän ensimmäinen käsky. Joissakin tapauksissa (yleensä käyttöjärjestelmän sisällä) halutaan keskeytymättä suorittaa jokin tietty konekäskyjen sarja alusta loppuun, mikä voidaan toteuttaa asettamalla I-bitti pois päältä (arvoon 0) vähäksi aikaa. Yleensä I-bittiä voi manipuloida vain etuoikeutetussa tilassa käyttöjärjestelmän koodissa.
+Bitti D (Interrupts disabled) kertoo, ovatko keskeytysten käsittelyt sallittuja tällä hetkellä (tämän konekäskyn suorituksen lopussa) vai ei. Jos jokin keskeytys tapahtuu ja bitti D ei ole päällä (arvo 0), niin seuraavaksi suoritettava konekäsky ei olekaan PC:n osoittama käsky vaan kyseisen keskeytystyypin keskeytyskäsittelijän ensimmäinen käsky. Joissakin tapauksissa (yleensä käyttöjärjestelmän sisällä) halutaan keskeytymättä suorittaa jokin tietty konekäskyjen sarja alusta loppuun, mikä voidaan toteuttaa asettamalla D-bitti päälle (arvoon 1) vähäksi aikaa. Yleensä D-bittiä voi manipuloida vain etuoikeutetussa tilassa käyttöjärjestelmän koodissa.
 
 Bitit G, E, L, O, Z, U, M ja S kertovat konekäskyn suorituksen päätyttyä, mitä suorittimella tapahtui tämän (tai muutaman aikaisemman) konekäskyn suorituksessa. Bitit G (Greater), E (Equal) ja L (Less) tallettavat vertailukäskyjen tuloksen. Vähän ehkä epäloogisesti niihin tallettuu myös tuloksen nollaan vertailu aritmetiikkaoperaatioiden jälkeen.
 
@@ -49,14 +49,14 @@ Bitit O, Z, U ja M laitetaan päälle, jos käskyn suorituksessa tapahtui jokin 
 
 Bitti S (Supervisor call) asetetaan päälle, jos suorituksessa oli SVC (SuperVisor Call) konekäsky. Sen toteutus on hyvin samanlainen virhetilanteiden käsittelyn kanssa. SVC-käskyssä sen vakiokentässä on halutun käyttöjärjestelmäpalvelun numero. Esimerkiksi ttk-91 suorittimella käyttöjärjestelmä palvelu 11 (symbolin HALT arvo) käsittää toimenpiteet, joilla meneillään olevan ohjelman suoritus lopetetaan.
 
-Bitti I (device Interrupt) kertoo, että tämän konekäskyn suorituksen aikana jokin ulkoinen laite aiheutti I/O-laitekeskeytyksen. I/O-laitekeskeytys tarkoittaa, että kyseinen I/O-laite (esim. levyohjain tai verkkokortti) haluaa kertoa jotain sen laitteen laiteajurille (käyttöjärjestelmään kuuluva palvelurutiini, joka suoritetaan suorittimella). Tässä tapauksessa keskeytyskäsittelijä siirtää kyseisen laiteajurin Valmis suoritukseen (Ready) -tilaan, josta se ennemmin tai myöhemmin pääsee suoritukseen ja keskustelemaan laitteen kanssa jatkotoimista. Tällaisia ulkoisia keskeytystilanteita voi olla muitakin (esim. kellolaitekeskeytys), mutta niitä ei ole toteutettu ttk-91 määrittelyssä.
+Bitti I (device Interrupt) kertoo, että tämän konekäskyn suorituksen aikana jokin ulkoinen laite aiheutti I/O-laitekeskeytyksen. I/O-laitekeskeytys tarkoittaa, että kyseinen I/O-laite (esim. levyohjain tai verkkokortti) haluaa kertoa jotain sen laitteen laiteajurille. (Laiteajuri on käyttöjärjestelmään kuuluva palvelurutiini, joka suoritetaan suorittimella.) Tässä tapauksessa keskeytyskäsittelijä siirtää kyseisen laiteajurin Valmis suoritukseen (Ready) -tilaan, josta se ennemmin tai myöhemmin pääsee suoritukseen ja keskustelemaan laitteen kanssa jatkotoimista. Tällaisia ulkoisia keskeytystilanteita voi olla muitakin (esim. kellolaitekeskeytys), mutta niitä ei ole toteutettu ttk-91 määrittelyssä.
 
-Kaikkien kesketystilanteiden (jokin biteistä G, E, L, O, Z, U, M, S on päällä ja samaan aikaan bitti I on päällä) käsittely on samanlainen. Nykyiset PC ja SR:n arvot otetaan johonkin (esim. pinoon) talteen, SR:n P-bitti (etuoikeutettu suoritustila) asetetaan päälle ja PC:n arvoksi asetetaan kyseisen keskeytystyypin keskeytyskäsittelijän alkuosoite. Esimerkiksi, bitti Z on talletettu tilarekisterin bittiin numero 27, joten nollalla jako -virheen käsittelevän keskeytyskäsittelijän osoite voi löytyä löytyy keskusmuistista (fyysisestä) osoitteesta 27 (0x0000001B).
+Kaikkien kesketystilanteiden (jokin biteistä G, E, L, O, Z, U, M, S on päällä ja samaan aikaan keskeytyksiä ei ole estetty eli bitti D ei ole päällä) käsittely on samanlainen. Nykyiset PC:n ja SR:n arvot otetaan johonkin (esim. pinoon) talteen, SR:n P-bitti (etuoikeutettu suoritustila) asetetaan päälle ja PC:n arvoksi asetetaan kyseisen keskeytystyypin keskeytyskäsittelijän alkuosoite. Esimerkiksi, bitti Z on talletettu tilarekisterin bittiin numero 27, joten nollalla jako -virheen käsittelevän keskeytyskäsittelijän osoite voi löytyä keskusmuistista (fyysisestä) osoitteesta 27 (0x0000001B).
 
 Todellisten suorittimien tilarekisterit ovat vastaavia, mutta niiden rakenne voi olla myös vähän erilainen. Joissakin suorittimissa vertailujen tulos otetaan talteen omaan vertailurekisteriin ja niitä voi olla useita. Tällöin konekäskyssä täytyy erikseen määritellä, minkä vertailurekisterin sisältöön mahdollinen ehdollinen haarautuminen perustuu.
 
 ### Muistinhallintayksikön rekisterit
-Konekieliset käskyt eivät tee suoraan (luku tai kirjoitus) muistiviittauksia keskusmuistiin, vaan kaikki viitteet tapahtuvat muistinhalllintayksikön (MMU, Memory Management Unit) kautta. Suorituksessa oleva ohjelma saa viitata vain omaan muistialueeseensa, mikä on kuvattu rekistereiden BASE ja LIMIT avulla. Ainoastaan käyttöjärjestelmä voi muokata noita rekistereitä.
+Konekieliset käskyt eivät tee suoraan (luku tai kirjoitus) muistiviittauksia keskusmuistiin, vaan kaikki viitteet tapahtuvat muistinhallintayksikön (MMU, Memory Management Unit) kautta. Suorituksessa oleva ohjelma saa viitata vain omaan muistialueeseensa, mikä on kuvattu rekistereiden BASE ja LIMIT avulla. Ainoastaan käyttöjärjestelmä voi muokata noita rekistereitä.
 
 Muistiväylän käyttö tapahtuu rekistereiden MBR (Memory Buffer Register), MAR (Memory Address Register) ja BusCtl rekistereiden avulla. Muistiin talletettava arvo kirjoitetaan MBR:ään, joka on suoraan yhteydessä muistiväylän dataväylään (muistiväylän ne johtimet, jotka siirtävät dataa). Osoite kirjoitetaan MAR:iin. Muistin kirjoituskomento asetetaan BUsCtl-rekisteriin ja tietyn ajan kuluttua haluttu data on kirjoitettu haluttuun muistipaikkaan keskusmuistissa. Operaation onnistuminen tulee tiedoksi kontrolliväylää pitkin samaan rekisteriin BusCtl. Muistista lukeminen tapahtuu vastaavasti.
 
@@ -67,9 +67,9 @@ Edellä mainittu väylän toiminta on selostettu huomattavan yksinkertaistetusti
 Useimmissa todellisissa suorittimissa muistinhallintayksikössä on myös [välimuisti](https://fi.wikipedia.org/wiki/V%C3%A4limuisti), josta viitattu data useimmiten löytyy. Välimuistin toteutus on jonkin verran monimutkainen, eikä sekään sisälly tämän kurssin oppimistavoitteisiin. Ttk-91 suorittimessa ei ole välimuistia.
 
 ## Konekäskyt
-Kaikilla ttk-91 koneen konekäskyillä on kaikilla sama muoto. 32-bittinen käsky on jaettu viiteen kenttään. Operaatiokoodi (8 bittiä) kertoo, mikä operatio on kyseessä. Rekisteri Rj (3 bittiä) määrittelee ensimmäisen operandin ja on samalla tulosrekisteri kaikille aritmeettis-loogisille käskyille.
+Kaikilla ttk-91 -koneen konekäskyillä on sama muoto. 32-bittinen käsky on jaettu viiteen kenttään. Operaatiokoodille on varattu 8 bittiä ja ne kertovat mikä operaatio on kyseessä. Rekisterille Rj (R0 - R7) on varattu 3 bittiä, jotka määrittävät ensimmäisen operandin. R_j on samalla tulosrekisteri kaikille aritmeettis-loogisille käskyille.
 
-Jälkimmäinen operandi (tai käskyn kohdeosoite) määritellään kolmen kentän avulla. Moodi-kenttä (2 bittiä) kertoo kuinka jälkimmäinen operandi (tai käskyn kohdeosoite) muodostetaan rekisterin Rj (3 bittiä) ja vakio-osan ADDR (16 bittiä) avulla.
+Jälkimmäinen operandi (tai käskyn kohdeosoite) määritellään kolmen kentän avulla. Moodi-kenttä (2 bittiä) kertoo kuinka jälkimmäinen operandi (tai käskyn kohdeosoite) muodostetaan rekisterin Ri (R0 - R7, joiden ilmaisuun on varattu 3 bittiä) ja vakio-osan ADDR (16 bittiä) avulla.
 
 ![Iso keltainen laatikko, jossa viisi kenttää kuvaamassa konekäskyn eri osia. Vasemmalta lukien OPCODE (8 bittiä), Rj (3 bittiä), moodi M (2 bittiä), Ri (3 bittiä) ja ADDR (16 bittiä). Alla esimerkki käsky ADD R2, =21(R5) joka lisää R2:n arvoon muistipaikan (R5+21) sisällön. Käskyn kentät vasemmalta ovat 00010001 (ADD), 010 (R2), 01 (suora muistiviite =), 101 (R5) ja 0x1B (21).](./ch-5-1-b-ttk91-konekaskyn-rakenne.svg)
 <div>
@@ -86,14 +86,14 @@ Jos moodi on nolla (M=0), niin jälkimmäinen operandi (sen arvo) on suoraan rek
 
 Jos halutaan indeksirekisterin ja vakio-osan summan asemesta käyttää vain indeksirekisterin arvoa, niin konekäskyssä vakio-osana on luku 0. Jos halutaan käyttää vain vakio-osaa ilman indeksirekisteriä, niin indeksirekisterikentässä on arvo 0. Tämän vuoksi ainoastaan rekistereitä R1-R5 voi käyttää indeksirekistereinä.
 
-Joidenkin käskyjen (store, jump, etc) yhteydessä toinen operandi on aina muistisoite. Se lasketaan samalla tavalla kuin aikaisemminkin, mutta moodi kentän arvo on aina yhtä pienempi, koska laskettua muistiosoitetta ei käytetä datan lukemiseen muistista. Store-käskyn yhteydessä suora muistiviite on koodattu moodilla 0 ja tieto talletetaan muistiosoitteeseen (Ri)+ADDR. Vastaavasti store-käskyn yhteydessä epäsuora muistiviite on koodattu moodilla ja tieto talletetaan muistiosoitteeseen, jonka osoite on muistissa osoitteessa (Ri)+ADDR. Hyppykäskyjen yhteydessä jälkimmäinen operandi (muistiosoite) talletetaan PC:n arvoksi.
+Joidenkin käskyjen (esimerkiksi STORE ja JUMP) yhteydessä toinen operandi on aina muistisoite. Se lasketaan samalla tavalla kuin aikaisemminkin, mutta moodi kentän arvo on aina yhtä pienempi, koska laskettua muistiosoitetta ei käytetä datan lukemiseen muistista. Store-käskyn yhteydessä suora muistiviite on koodattu moodilla 0 ja tieto talletetaan muistiosoitteeseen (Ri)+ADDR. Vastaavasti store-käskyn yhteydessä epäsuora muistiviite on koodattu moodilla ja tieto talletetaan muistiosoitteeseen, jonka osoite on muistissa osoitteessa (Ri)+ADDR. Hyppykäskyjen yhteydessä jälkimmäinen operandi (muistiosoite) talletetaan PC:n arvoksi.
 
-Erilaisten moodien käyttö voi tuntua aluksi sekavalta, muta suorittimelle ne ovat hyvin yksinkertaisia ja tukevat hyvin yleisiä muistinviittaustapoja.
+Erilaisten moodien käyttö voi tuntua aluksi sekavalta, mutta suorittimelle ne ovat hyvin yksinkertaisia ja tukevat hyvin yleisiä muistinviittaustapoja.
 
-Nykyissä todellisissa suorittimissa on enää hyvin harvoin epäsuoraa muistinosoitusmoodia, koska jo yksikin muistiviite käskyn sisällä kestää harmillisen kauan laskentaan suhteutettuna. Samasta syystä nykyisissä suorittimissa muistinviittauskäskyjä ei enää yhdistetä aritmeettis-loogisiin käskyihin, vaan ne on tuoteutettu ihan erillisinä kaikista muista operaatioista. Ttk-91 suorittimessa nopeus ei ole tärkeää, joten sama käsky voi hakea operandin arvon muistista epäsuoraa muistiosoitusta käyttäen ja vielä samalla kertaa suorittaa sillä kertolaskuoperaation.
+Nykyissä todellisissa suorittimissa on enää hyvin harvoin epäsuoraa muistinosoitusmoodia, koska jo yksikin muistiviite käskyn sisällä kestää harmillisen kauan laskentaan suhteutettuna. Samasta syystä nykyisissä suorittimissa muistinviittauskäskyjä ei enää yhdistetä aritmeettis-loogisiin käskyihin, vaan ne on toteutettu erillisinä kaikista muista operaatioista. Ttk-91 suorittimessa nopeus ei ole tärkeää, joten sama käsky voi hakea operandin arvon muistista epäsuoraa muistiosoitusta käyttäen ja vielä samalla kertaa suorittaa sillä kertolaskuoperaation.
 
 ### Muistitilan käyttö
-Ohjelman suoritusaikana käyttämä muistialue on rajattu rajarekisteriparilla BASE ja LIMIT. Ohjelmalle (sitä suorittavalle prosessille) varattu kooltaan rekisterin LIMIT osoittama muistialue, joka alkaa rekisterin BASE osoittamasta muistipaikasta. Ohjelman konekäskyissä käyttämät muistiosoitteet ovat välillä \[0, LIMIT) ja MMU tarkistaa *jokaisen* muistiviitteen kohdalla, että käytetty muistisoite on tosiaan tuolla välillä \[0, LIMIT). Jos näin ei ole, niin käskyn suoritus keskeytyy ja suoritin aiheuttaa muistiviitekeskeytyksen (tilarekisterin bitti M ttk-91 suorittimessa). Jos muistiosoite on sallitulla välillä, MMU lisää siihen BASE-rekisterin arvon ja välittää näin saadun todellisen (fyysisen) muistiosoitteen väylän kautta keskusmuistille muistista lukua tai kirjoittamista varten.
+Ohjelman suoritusaikana käyttämä muistialue on rajattu rajarekisteriparilla BASE ja LIMIT. Ohjelmalle (sitä suorittavalle prosessille) varattu kooltaan rajarekisterin LIMIT osoittama muistialue, joka alkaa kantarekisterin BASE osoittamasta muistipaikasta. Ohjelman konekäskyissä käyttämät muistiosoitteet ovat välillä \[0, LIMIT) ja muistinhallintayksikkö MMU tarkistaa *jokaisen* muistiviitteen kohdalla, että käytetty muistisoite on tosiaan tuolla välillä \[0, LIMIT). Jos näin ei ole, niin käskyn suoritus keskeytyy ja suoritin aiheuttaa muistiviitekeskeytyksen (tilarekisterin bitti M ttk-91 suorittimessa). Jos muistiosoite on sallitulla välillä, MMU lisää siihen BASE-rekisterin arvon ja välittää näin saadun todellisen (fyysisen) muistiosoitteen väylän kautta keskusmuistille muistista lukemista tai kirjoittamista varten.
 
 <!-- kuva: ch-5-1-c-ttk91-muistitilan-kaytto   # kalvo 5.12  -->
 
@@ -104,11 +104,11 @@ Ohjelman suoritusaikana käyttämä muistialue on rajattu rajarekisteriparilla B
 
 Todellisissa suorittimissa voi kanta- ja rajarekisteripareja olla useita, jolloin jokainen niistä rajaa yhden muistisegmentin ohjelman käyttöön. Tällaisia segmenttejä voivat olla esimerkiksi ohjelman koodisegmentti, datasegmentti, pinosegmentti, jne. Kaikki ohjelman koodiosoitteet kuvataan automaatisesti koodisegmenttiin, dataviitteet datasegmenttiin, ja pinoviitteet (rekisterin SP kautta) pinosegmenttiin, jne.
 
-Usean muistisegmentin lisäksi tai niiden asemesta ohjelman käytössä oleva muistialue voidaan jakaa pienehköihin (esim. 4 KB) saman kokoisiin *sivuihin*, jotka kukin voidaan sijoittaa mihin tahansa keskusmuistissa olevaan saman kokoiseen *sivukehykseen*. Kirjanpito ohjelman hallussa olevista sivukehyksistä ja niissä kulloinkin olevista sivuista on tietenkin aika monimutkaista. Samoin on osoitteenmuutosten laita, koska jokaisen muistiviitteen kohdalla pitää selvittää, missä sivukehyksessä viitattu muistipaikka tällä hetkellä sijaitsee. Tällainen *virtuaalimuisti* on kuitenkin hyvin joustava muistinhallinnan suhteen, koska ohjelmalle varattujen muistialueiden ei tarvitse olla yhtenäisillä muistialueilla. Virtuaalimuistin tuki on sen vuoksi toteutettu useimpiin nopeisiin suorittimiin ja virtuaalimuisti useimpiin nykyaikaisiin käyttöjärjestelmiin. Virtuaalimuistin yksityiskohdat eivät kuulu tämän kurssin oppimistavoitteisiin, vaan niitä käsitellään käyttöjärjestelmät-kursseilla.
+Usean muistisegmentin lisäksi tai niiden asemesta ohjelman käytössä oleva muistialue voidaan jakaa pienehköihin (esim. 4 KB) saman kokoisiin *sivuihin*, jotka kukin voidaan sijoittaa mihin tahansa keskusmuistissa olevaan saman kokoiseen *sivukehykseen*. Kirjanpito ohjelman hallussa olevista sivukehyksistä ja niissä kulloinkin olevista sivuista on tietenkin aika monimutkaista. Samoin on osoitteenmuutosten laita, koska jokaisen muistiviitteen kohdalla pitää selvittää, missä sivukehyksessä viitattu muistipaikka tällä hetkellä sijaitsee. Tällainen *virtuaalimuisti* on kuitenkin hyvin joustava muistinhallinnan suhteen, koska ohjelmalle varattujen muistialueiden ei tarvitse olla yhtenäisillä muistialueilla. Virtuaalimuistin tuki on sen vuoksi toteutettu useimpiin nopeisiin suorittimiin ja virtuaalimuisti useimpiin nykyaikaisiin käyttöjärjestelmiin. Virtuaalimuistin yksityiskohdat eivät kuulu tämän kurssin oppimistavoitteisiin, vaan niitä käsitellään Käyttöjärjestelmät-kurssilla.
 
 ## Muistiinviittaustavat
 
-Ttk-91:ssä on oikeastaan vain yksi muistiinviitaustapa, indeksoitu muistiinviittaus, ja sitä voidaan käyttää vain konekäskyn jälkimmäisen operandin yhteydessä. Viitattu muistiosoite lasketaan aina konekäskyssä mainitun indeksirekisterin (r1-r7) ja käskyssä olevan vakion summan avulla. Jos indeksirekisteriä ei haluta tässä yhteydessä käyttää, niin se on koodattu käskyyn indeksirekisterinä r0. Jos vakiota ei haluta käyttää, niin se on koodattu käskyyn vakiona 0.
+Ttk-91:ssä on oikeastaan vain yksi muistiinviitaustapa, indeksoitu muistiinviittaus, ja sitä voidaan käyttää vain konekäskyn jälkimmäisen operandin yhteydessä. Viitattu muistiosoite lasketaan aina konekäskyssä mainitun indeksirekisterin (R1 - R7) ja käskyssä olevan vakion summan avulla. Jos indeksirekisteriä ei jossakin konekäskyssä ohjelmakoodia kirjoittaessa halua käyttää, kääntäjä asettaa indeksirekisteriksi konekäskyn koodiin rekisterin R0. Jos taas vakiota ei tarvitse jossakin konekäskyssä käyttää, kääntäjä tulkitsee, että on tarkoitettu että vakio on 0 ja asettaa konekäskyn vakio-osaan luvun 0.
 
 Näin saadun summan avulla konekäskyn jälkimmäinen operandi saadaan kolmella eri tavalla, mikä on koodattu konekäskyn moodi kenttään. Moodin arvo 0 (_välitön tiedonosoitus_) tarkoittaa, että tuo äsken laskettu "muistiosoite" on sellaisenaan toinen operandi, eikä mitään muistiviitettä tarvita. Moodin arvo 1 (_suora muistiviite_) tarkoittaa, että muistiosoitetta käytetään yhden kerran operandin hakemiseksi muistista. Moodin arvo 2 (_epäsuora muistiviite_) tarkoittaa, että ensin haetaan muistista edellä laskettua muistiosoitetta käyttäen toisen operandin osoite ja vasta sitten haetaan muistista tuota osoitetta käyttämällä jälkimmäinen operandi.  (Tarkempi selitys on esitelty luvussa 2.3)
 
@@ -131,10 +131,10 @@ store r1, 7(r2)  -- 1      1        0     0        7  mem(17) <- 3
 store r1, @7(r2) -- 1      1        1     0        7  mem(45) <- 3
 ```
 
-Käskyn moodi-kentän arvon kertoo siis muistista _lukujen_ lukumäärän käskyn suoritusaikana. Muistiin kirjoituskäskyn (STORE) yhteydessä moodikentän arvo on yhtä pienempi kuin vastaavassa muistin lukukäskyssä (LOAD) ja sillä tarkoitetaan aina suoraa tai epäsuoraa muistiviitettä. Käskyn suoritusaikana STORE-käskyssä tulee lopuksi aina yksi muistiin _kirjoitus_.
+Käskyn moodi-kentän arvo kertoo siis muistista _lukemisten_ lukumäärän käskyn suoritusaikana. Muistiin kirjoituskäskyn (STORE) yhteydessä moodikentän arvo on yhtä pienempi kuin vastaavassa muistin lukukäskyssä (LOAD) ja sillä tarkoitetaan aina suoraa tai epäsuoraa muistiviitettä. Käskyn suoritusaikana STORE-käskyssä tulee lopuksi aina yksi muistiin _kirjoitus_.
 
 ## Tiedon esitysmuodot
-Ttk-91 suorittimessa on aritmeettis-loogisia operaatioita vain kahden tyyppiselle 32-bittiselle datalle. Kokonaisluvuille on kaikki perustoiminnot (add, sub, mul, div ja mod). Jos jakolaskusta halutaan sekä osamäärä että jakojäännös, niin ensi täytyy laskea osamäärä div-operaatiollaja sitten jakojäännös mod-operaatiolla.
+Ttk-91 suorittimessa on aritmeettis-loogisia operaatioita vain kahden tyyppiselle 32-bittiselle datalle. Kokonaisluvuille on kaikki perustoiminnot (ADD, SUB, MUL, DIV JA MOD). Jos jakolaskusta halutaan sekä osamäärä että jakojäännös, niin ensin täytyy laskea osamäärä DIV-operaatiolla ja sitten jakojäännös MOD-operaatiolla.
 
 ```
 load r3, =13
@@ -143,16 +143,16 @@ load r4, =13
 mod  r4, =5   ; rekisterissä r4 on nyt jakojäännös 3
 ```
 
-Lisäksi kokonaisluvuille on niiden vertailukäsky (comp) ja ensimmäisen operandin perusteella tapahtuvat ehdolliset hyppykäskyt.
+Lisäksi kokonaisluvuille on niiden vertailukäsky (COMP) ja ensimmäisen operandin perusteella tapahtuvat ehdolliset hyppykäskyt.
 
 ```
 comp  r1, =7  ; aseta vertailun (r1 arvo vs. 7) tulos tilarekisteriin SR
-jeq   Found   ; hyppää osoitt. Found, jos SR:ssä vertailubitin E arvo on 1
+jequ   Found   ; hyppää osoitt. Found, jos SR:ssä vertailubitin E arvo on 1
 ...
 jneg  r1, Negat  ; hyppää osoitt. Negat, jos r1:n arvo on negatiivinen
 ```
 
-Toinen kategoria aritmeettis-loogisille operaatioille on bittimanipulaatio kaikille 32 bitille. Nämä operaatiot ovat and, or, xor, not, shl, shr, ja shra. And, or ja xor tekevät oman loogisen operaationsa pareittain kaikille 32-bitille operandien välillä. Operaatiolla not on vain yksi operandi, jonka kaikki bit käännetään. Operaatiot shl ja shr siirtävät ensimmäisen operandin bittejä oikealle tai vasemmalle jälkimmäisen operandin osoittaman määrän bittejä, täyttäen 0-bitillä. Operaatio shra toimii kuten shr, mutta täytettävä bitti on vasemmanpuolimmainen (etumerkki) bitti.
+Toinen kategoria aritmeettis-loogisille operaatioille on bittimanipulaatio kaikille 32 bitille. Nämä operaatiot ovat AND, OR, XOR, NOT, SHL, SHR ja SHRA. And, or ja xor tekevät oman loogisen operaationsa pareittain kaikille 32 bitille bitti kerrallaan operandien välillä. Operaatiolla not on vain yksi operandi, jonka kaikki bitit käännetään (0->1 ja 1->0). Operaatio SHL (shift left) siirtää ensimmäisen operandin bittejä vasemmalle jälkimmäisen operandin osoittaman määrän verran ja täyttää nollilla kyseisen määrän verran oikeanpuoleisia bittejä. SHR (shift right) vastaavasti siirtää bittejä oikealle ja täyttää nollilla vasemmalta puolelta siirtyneet bitit. Operaatio SHRA toimii kuten SHR, mutta täytettävä bitti on vasemmanpuolimmainen (etumerkki) bitti.
 
 ```
 load r1, =12   ; r1 = 00000000 00000000 00000000 0000 1100
@@ -188,7 +188,7 @@ X   add  r1, r2      ; käsky, joka halutaan jakaa osiin
                      ; r3:ssa on nyt käskyn X operaatiokoodi on 17, eli add
 ```
 
-Lisäksi on muistin lukukäsky load. Sitä voi käyttää myös kopioimaan tietoja rekisteristä toiseen, kunhan vain lähderekisteri ei ole rekisteri r0. Muistin kirjoituskäsky store kirjoittaa aina jotain muistiin, joten jälkimmäisen operandin täytyy olla laillinen muistiosoite.
+Muistista lukemiseen käytetään lukukäskyä LOAD. Sitä voi käyttää myös kopioimaan tietoja rekisteristä toiseen, kunhan vain lähderekisteri ei ole rekisteri r0. Muistin kirjoituskäsky STORE kirjoittaa aina jotain muistiin, joten jälkimmäisen operandin täytyy olla laillinen muistiosoite.
 
 ```
     load  r1, r2     ; kopioi rekisterin r2 arvo rekisteriin r1
@@ -211,7 +211,7 @@ Ttk-91:ssä on myös yksinkertaiset konekäskyt tiedon lukemiseen näppäimistö
     out   r2, =crt   ; tulosta näytölle rekisterin r2 arvo
 ```
 
-Eri laitteiden käyttö tapahtuu usein vähän monimutkaisemmin, ns. *muistiinkuvattua* I/O:ta käyttäen. Tuolloin laitteiden käyttö ei ole toteutettu omilla konekäskyillään, vaan osa muistiavaruudesta (osoitettavissa olevista muistiosoitteista) on varattu I/O-laitteita varten. Laitteiden kanssa kommunikoidaan tuolloin tavallisilla muistin luku- ja kirjoituskäskyillä. Tätä käsitellään tarkemmin luvussa 8 I/O:n toteutuksen yhteydessä.
+Eri laitteiden käyttö tapahtuu usein vähän monimutkaisemmin, *muistiinkuvattua* I/O:ta käyttäen. Tuolloin laitteiden käyttö ei ole toteutettu omilla konekäskyillään, vaan osa muistiavaruudesta (osoitettavissa olevista muistiosoitteista) on varattu I/O-laitteita varten. Laitteiden kanssa kommunikoidaan tuolloin tavallisilla muistin luku- ja kirjoituskäskyillä. Tätä käsitellään tarkemmin luvussa 8 I/O:n toteutuksen yhteydessä.
 
 ```
     store  r2, =disk_control  ; anna komento kovalevyn laiteohjaimelle
@@ -219,9 +219,9 @@ Eri laitteiden käyttö tapahtuu usein vähän monimutkaisemmin, ns. *muistiinku
 ```
 
 ## Kääntäjän ohjauskäskyt
-Symbolinen konekieli siis "puhtaasta" konekielestä siinä, että siinä voidaan käyttää erilaisia *symboleja* pelkkien numeroiden asemesta (ks. luku 1.2). Symbolisella konekielellä kirjoitettu ohjelma on ohjelmoijille aika helppolukuista ja se suhteellisen helppo kääntää puhtaan numeeriseen konekieliseen esitysmuotoon. Kääntämistä käsitellään tarkemmin luvussa 9.
+Symbolinen konekieli eroaa "puhtaasta" konekielestä siinä, että siinä voidaan käyttää erilaisia *symboleja* pelkkien numeroiden asemesta (ks. luku 1.2). Symbolisella konekielellä kirjoitettu ohjelma on ohjelmoijille aika helppolukuista ja se suhteellisen helppo kääntää puhtaan numeeriseen konekieliseen esitysmuotoon. Kääntämistä käsitellään tarkemmin luvussa 9.
 
-Symbolisen konekielen käskyjen lisäksi koodissa voi olla ohjauskäskyjä *symbolisen konekielen kääntäjälle*, joka voi vielä välittää jotkut ohjauskäskyt *lataajalle*. Tällaisia käskyjä sanotaan *pseudokäskyiksi* tai *valekäskyiksi*, koska ne näyttävät konekäskyiltä, mutta eivät kuitenkaan ole suoritettavaa koodia. Ttk-91:ssä on vain kolme valekäskyä. Ohjauskäskyllä DC (data constant) varataan tilaa muistista kokonaislukuarvoiselle muuttujalle tai vakiolle arvo ja annetaan sille alkuarvo. Vakio eroaa muuttujasta siinä, että sen arvoa ei muuteta koodissa. Ohjauskäskyllä DS (data segment) varataan vain tilaa yhden tai useamman sanan verran muistista. Molemmilla ohjauskäskyillä DC ja DS määritellään myös symbolit, joiden arvoiksi tulee varattujen muistialueiden osoite. Lisäksi ohjauskäskyllä EQU (equal) määritellään uusi symboli ja sen arvo. Näin määritelty symboli ei saa olla mikään aikaisemmin käytössä oleva symboli, joten esimerkiksi symbolille "ADD" ei voi määritellä uutta arvoa.
+Symbolisen konekielen käskyjen lisäksi koodissa voi olla ohjauskäskyjä *symbolisen konekielen kääntäjälle*, joka voi vielä välittää jotkut ohjauskäskyt *lataajalle*. Tällaisia käskyjä sanotaan *pseudokäskyiksi* tai *valekäskyiksi*, koska ne näyttävät konekäskyiltä, mutta eivät kuitenkaan ole suoritettavaa koodia. Ttk-91:ssä on kolme valekäskyä. Ohjauskäskyllä DC (data constant) varataan tilaa muistista kokonaislukuarvoiselle muuttujalle tai vakiolle ja annetaan sille alkuarvo. Vakio eroaa muuttujasta siinä, että vakion arvoa ei saa muuttaa koodissa. Ohjauskäskyllä DS (data segment) varataan tilaa yhden tai useamman sanan verran muistista taulukoita ja tietueita varten. Molemmilla ohjauskäskyillä DC ja DS määritellään myös symbolit, joiden arvoiksi tulee varattujen muistialueiden osoite. Lisäksi ohjauskäskyllä EQU (equal) määritellään uusi symboli ja sen arvo. EQu-ohjauskäskyllä määriteltyä arvoa ei pysty muuttamaan ohjelman suorittamisen aikana, joten se on turvallinen tapa määritellä vakiolle arvo. Ohjauskäskyssä annettu symboli ei saa olla mikään aikaisemmin käytössä oleva symboli, joten esimerkiksi symbolille "ADD" ei voi määritellä uutta arvoa.
 
 ```
 big dc 87654321 ; suuri vakio, joka on talletettu muistiin
@@ -230,11 +230,12 @@ x   dc    0     ; muuttuja x, alkuarvo 0
 tbl_n  equ   50    ; ohjelmassa käytetyn taulukon koko, symbolin arvo 50
 ```
 
-Jos edellämainitut valekäskyt sijaitsevat annetussa järjestyksessä missä päin tahansa ohjelmakoodia ja ohjelmakoodin pituus on 85 konekäskyä (osoitteissa 0-84), niin symbolin big arvoksi tulee 85, symbolin tbl arvoksi 86 ja symbolin x arvoksi 136. Ttk-91:hän globaaleille tietorakenteille varataan tilaa muistissa heti koodisegmentin (ohjelman koodi) jälkeen. Vakio big on siis osoitteessa 86 ja sen arvo on 87654321, alustamaton taulukko tbl osoitteessa 86 ja muuttuja x osoitteessa 136. Taulukon koko 50 on symbolin tbl_n arvona, jolloin taulukon kokoon viitataan ohjelmakoodissa vain symbolin tbl_n avulla.
+Ttk-91:ssä globaaleille tietorakenteille varataan tilaa muistissa heti koodisegmentin (ohjelman koodi) jälkeen. Jos edellämainitut valekäskyt sijaitsevat annetussa järjestyksessä missä päin tahansa ohjelmakoodia ja ohjelmakoodin pituus on 85 konekäskyä (osoitteissa 0-84), niin symbolin big arvoksi tulee 85, symbolin tbl arvoksi 86 ja symbolin x arvoksi 136. Vakio big on siis osoitteessa 85 ja sen arvo on 87654321. Alustamattoman taulukon tbl alkioita varten on varattu osoitteet 86 - 135. Taulukon indeksissä 0 säilytettävän alkion arvo sijaitsee osoitteessa 0 + 86 = 86, indeksissä 1 oleva alkio osoitteessa 1 + 86 = 87 ja niin edelleen. Muuttuja x on osoitteessa 136. Taulukon koko 50 on symbolin tbl_n arvona, jolloin taulukon kokoon voidaan viitata ohjelmakoodissa symbolin tbl_n avulla.
 
-Todelisissa suorittimissa on muitakin kääntäjän ohjauskäskyjä. Esimerkiksi ehdollista kääntäminen sallii samojen asioiden tekemisen vähän eri tavalla suorittimen eri versioilla. Näin kääntäjä generoi kullekin suoritinversiolle sille sopivan koodin.
+Todellisissa suorittimissa on muitakin kääntäjän ohjauskäskyjä. Esimerkiksi ehdollinen kääntäminen sallii samojen asioiden tekemisen vähän eri tavalla suorittimen eri versioilla. Näin kääntäjä generoi kullekin suoritinversiolle sille sopivan koodin.
 
 ```
+; Esimerkki ehdollisesta kääntämisestä (Tätä ei ole ttk-91:ssä.)
 _ifdef_ _floats_  ; onko suoritinversiossa liukulukukäskyjä?
     fadd   f1, f2, f3      ; laske liukulukukäskyillä
 _else_            ; ei ole. tee liukulukulaskenta keskeytyskäsittelijässä
@@ -249,10 +250,10 @@ _endif_
 <text-box variant="example" name="Tärkeitä termejä">
 
 ### Symbolinen konekieli
-Ohjelmakoodin esitystapa, jossa konekäskyjen useat kentät voidaan esittää symbolien avulla. Esimerkiksi käskykoodi voi olla "add", eikä vain yhteenlaskukäskyn numeerinen käskykoodi 17. Samoin muuttujiin voidaan viitata niiden nimien (esim "x") avulla, eikä niiden muistiosoitteiden avulla. Lisäksi konekäskyt kentät erottuvat toisistaan selkeästi, kun konekielessä kaikki kentät muodostavat vain yhden suuren kokonaisluvun.
+Ohjelmakoodin esitystapa, jossa konekäskyjen useat kentät voidaan esittää symbolien avulla. Esimerkiksi käskykoodi voi olla "add", eikä vain yhteenlaskukäskyn numeerinen käskykoodi 17. Samoin muuttujiin voidaan viitata niiden nimien (esim. "x") avulla, eikä niiden muistiosoitteiden avulla. Lisäksi konekäskyn kentät erottuvat symbolisessa toisistaan selkeästi ja ihmisen ymmärtämässä muodossa, kun konekielessä kaikki kentät muodostavat vain yhden suuren kokonaisluvun.
 
-### Konekieli tai "Puhdas" konekieli
-Ohjelman suorittimelle sopivat esitystapa, jossa kukin konekäsky on yksi iso kokonaisluku. Konekielinen esitysmuoto saadaan kääntämällä ohjelma joko sen symbolisen konekielen esitysmuodosta tai korkean tason kielen esitysmuodosta.
+### Konekieli tai "puhdas" konekieli
+Tietokoneen suorittimelle sopiva ohjelman esitystapa, jossa kukin konekäsky on yksi iso kokonaisluku. Konekielinen esitysmuoto saadaan kääntämällä ohjelma joko sen symbolisen konekielen esitysmuodosta tai korkean tason kielen esitysmuodosta.
 
 ### Indeksoitu muistiinviittaus
 Yleinen muistiinviitatustapa, jossa viitattu muistiosoite muodostetaan laskemalla yhteen konekäskyssä nimetyn rekisterin arvo ja konekäskyssä annetun vakion arvo.
@@ -264,10 +265,10 @@ Ohjelmassa käytettyjen muistiosoitteiden joukko.
 Ohjelmassa viitattujen todellisten keskusmuistiosoitteiden joukko.
 
 ### Muistinkuvaus
-Koska looginen ja fyysinen muistiavaruus ovat erilaisia, jokainen ohjelman käyttämä (looginen) muistiosoite pitää suoritusaikana kuvata (muuttaa) todelliseksi keskusmuistiosoitteeksi. Tähän on erilaisia menetelmiä. Ttk-91:ssä käytetään kanta- ja rajarekisteriaparia. Todellisissa nykyaikaisissa suorittimissa käytetään *virtuaalimuistiteknologiaa*.
+Koska looginen ja fyysinen muistiavaruus ovat erilaisia, jokainen ohjelman käyttämä (looginen) muistiosoite pitää suoritusaikana kuvata (muuttaa) todelliseksi keskusmuistiosoitteeksi. Tähän on erilaisia menetelmiä. Ttk-91:ssä käytetään kanta- ja rajarekisteriparia. Todellisissa nykyaikaisissa suorittimissa käytetään *virtuaalimuistiteknologiaa*.
 
 ### Pino
-Ohjelman käytössä oleva muistialue, johon viitataan erityisen pinorekisterin (ttk-91:ssä SP eli R6) avulla. Pinoa voidaan käyttää laskennan aikaisten välitulosten tallettamiseen ja aliohjelmien (fukntioiden, metodien) toteuttamiseen.
+Ohjelman käytössä oleva muistialue, johon viitataan erityisen pinorekisterin (ttk-91:ssä SP eli R6) avulla. Pinoa voidaan käyttää laskennan aikaisten välitulosten tallettamiseen ja aliohjelmien (funktioiden, metodien) toteuttamiseen.
 
 ### Keko
 Ohjelman käytössä oleva muistialue, josta ohjelman suorituksen aikana voidaan dynaamisesti varata ja vapauttaa käytettäviä muistilohkoja. Koko keko on ohjelman suorituksen aikana varattu ohjelmalle, vaikka tietyllä hetkellä se käyttääkin vain joitakin muistilohkoja keon sisällä.
@@ -279,7 +280,7 @@ Ohjelman käytössä oleva muistialue, josta ohjelman suorituksen aikana voidaan
 
 <!-- quiz 5.1.1 Pitääkö  -->
 <!--
-Ohjelman suoritukselle on varattu 1000 sanaa muistia ja se on talletettu muistialueelle 21000-21999. BASE-rekisterin arvo on siis 21000 ja LIMIT-rekisterin arvo on 1000. Muuttuja X on talletettu (ohjelman käyttämään) muistiosoitteseen 123 ja sen arvo on 144. Muuttuja Y on talletettu muistiosoitteseen 124 ja sen arvo on 1. Muuttuja ptrX on talletettu muistiosoitteeseen 144 ja sen arvo on 123. Symboli Small on määäritelty equ-valekäskyllä "Small equ 144". Rekisterin r3 arvo 1 ja rekisterin r4 arvo on 123.
+Ohjelman suoritukselle on varattu 1000 sanaa muistia ja se on talletettu muistialueelle 21000-21999. BASE-rekisterin arvo on siis 21000 ja LIMIT-rekisterin arvo on 1000. Muuttuja X on talletettu (ohjelman käyttämään) muistiosoitteseen 123 ja sen arvo on 144. Muuttuja Y on talletettu muistiosoitteseen 124 ja sen arvo on 1. Muuttuja ptrX on talletettu muistiosoitteeseen 144 ja sen arvo on 123. Symboli Small on määritelty equ-valekäskyllä "Small equ 144". Rekisterin r3 arvo 1 ja rekisterin r4 arvo on 123.
 
 Quiz 5.1.1 Mikä on symbolin x arvo?
 Quiz 5.1.2 Mikä on symbolin ptrX arvo?

--- a/data/luku-5/1-ttk-91.md
+++ b/data/luku-5/1-ttk-91.md
@@ -69,7 +69,7 @@ Useimmissa todellisissa suorittimissa muistinhallintayksikössä on myös [väli
 ## Konekäskyt
 Kaikilla ttk-91 -koneen konekäskyillä on sama muoto. 32-bittinen käsky on jaettu viiteen kenttään. Operaatiokoodille on varattu 8 bittiä ja ne kertovat mikä operaatio on kyseessä. Rekisterille Rj (R0 - R7) on varattu 3 bittiä, jotka määrittävät ensimmäisen operandin. R_j on samalla tulosrekisteri kaikille aritmeettis-loogisille käskyille.
 
-Jälkimmäinen operandi (tai käskyn kohdeosoite) määritellään kolmen kentän avulla. Moodi-kenttä (2 bittiä) kertoo kuinka jälkimmäinen operandi (tai käskyn kohdeosoite) muodostetaan rekisterin Ri (R0 - R7, joiden ilmaisuun on varattu 3 bittiä) ja vakio-osan ADDR (16 bittiä) avulla.
+Jälkimmäinen operandi (tai käskyn kohdeosoite) määritellään kolmen kentän avulla. Moodi-kenttä (2 bittiä) kertoo kuinka jälkimmäinen operandi (tai käskyn kohdeosoite) muodostetaan rekisterin Ri (R1 - R7, joiden ilmaisuun on varattu 3 bittiä) ja vakio-osan ADDR (16 bittiä) avulla.
 
 ![Iso keltainen laatikko, jossa viisi kenttää kuvaamassa konekäskyn eri osia. Vasemmalta lukien OPCODE (8 bittiä), Rj (3 bittiä), moodi M (2 bittiä), Ri (3 bittiä) ja ADDR (16 bittiä). Alla esimerkki käsky ADD R2, =21(R5) joka lisää R2:n arvoon muistipaikan (R5+21) sisällön. Käskyn kentät vasemmalta ovat 00010001 (ADD), 010 (R2), 01 (suora muistiviite =), 101 (R5) ja 0x1B (21).](./ch-5-1-b-ttk91-konekaskyn-rakenne.svg)
 <div>


### PR DESCRIPTION
Kielenhuoltoa ja täsmennyksiä. Lisäksi, ttk-91:n tilarekisterissä bitti I on device Interrupt, ei Interrupts enabled. Interrupts enabled -bittiä ei ole. Sen sijaan on bitti D eli interrupts disabled. D=0, kun keskeytyksiä ei ole estetty (normaali tilanne) ja D=1 jos keskeytykset on estetty.